### PR TITLE
Feature/vis 244 self supervised video learning

### DIFF
--- a/siampose/checkpointing.py
+++ b/siampose/checkpointing.py
@@ -188,39 +188,21 @@ class ModelCheckpointLastOnly(Callback):
         epoch = trainer.current_epoch
         global_step = trainer.global_step
 
-        # if (
-        #    trainer.fast_dev_run  # disable checkpointing with fast_dev_run
-        #    or self.save_top_k == 0  # no models are saved
-        #    or self.period < 1  # no models are saved
-        #    or (epoch + 1) % self.period  # skip epoch
-        #    or trainer.running_sanity_check  # don't save anything during sanity check
-        #    or self._last_global_step_saved == global_step  # already saved at the last step
-        # ):
-        #    return
-
-        #self._add_backward_monitor_support(trainer)
-        # self._validate_monitor_key(trainer)
-
         # track epoch when ckpt was last checked
         self._last_global_step_saved = global_step
 
         # what can be monitored
-        # monitor_candidates = self._monitor_candidates(trainer)
 
         # callback supports multiple simultaneous modes
         # here we call each mode sequentially
         # Mode 1: save all checkpoints OR only the top k
-        # if self.save_top_k:
-        #    self._save_top_k_checkpoints(trainer, pl_module, monitor_candidates)
 
         # Mode 2: save the last checkpoint
         self._save_last_checkpoint(trainer, pl_module)
 
     def __validate_init_configuration(self):
         if self.save_top_k is not None and self.save_top_k < -1:
-            raise MisconfigurationException(
-                f"Invalid value for save_top_k={self.save_top_k}. Must be None or >= -1"
-            )
+            raise MisconfigurationException(f"Invalid value for save_top_k={self.save_top_k}. Must be None or >= -1")
         if self.monitor is None:
             # None: save last epoch, -1: save all epochs, 0: nothing is saved
             if self.save_top_k not in [None, -1, 0]:
@@ -292,15 +274,13 @@ class ModelCheckpointLastOnly(Callback):
 
         if mode == "auto":
             rank_zero_warn(
-                "mode='auto' is deprecated in v1.1 and will be removed in v1.3."
-                " Default value for mode with be 'min' in v1.3.",
+                "mode='auto' is deprecated in v1.1 and will be removed in v1.3." " Default value for mode with be 'min' in v1.3.",
                 DeprecationWarning,
             )
 
             mode_dict["auto"] = (
                 (-torch_inf, "max")
-                if monitor is not None
-                and ("acc" in monitor or monitor.startswith("fmeasure"))
+                if monitor is not None and ("acc" in monitor or monitor.startswith("fmeasure"))
                 else (torch_inf, "min")
             )
 
@@ -377,9 +357,7 @@ class ModelCheckpointLastOnly(Callback):
 
         return filename
 
-    def format_checkpoint_name(
-        self, epoch: int, step: int, metrics: Dict[str, Any], ver: Optional[int] = None
-    ) -> str:
+    def format_checkpoint_name(self, epoch: int, step: int, metrics: Dict[str, Any], ver: Optional[int] = None) -> str:
         """Generate a filename according to the defined template.
         Example::
             >>> tmpdir = os.path.dirname(__file__)
@@ -399,9 +377,7 @@ class ModelCheckpointLastOnly(Callback):
             >>> os.path.basename(ckpt.format_checkpoint_name(0, 0, {}))
             'step=0.ckpt'
         """
-        filename = self._format_checkpoint_name(
-            self.filename, epoch, step, metrics, prefix=self.prefix
-        )
+        filename = self._format_checkpoint_name(self.filename, epoch, step, metrics, prefix=self.prefix)
         if ver is not None:
             filename = self.CHECKPOINT_JOIN_CHAR.join((filename, f"v{ver}"))
 
@@ -430,15 +406,9 @@ class ModelCheckpointLastOnly(Callback):
             else:
                 save_dir = trainer.logger.save_dir or trainer.default_root_dir
 
-            version = (
-                trainer.logger.version
-                if isinstance(trainer.logger.version, str)
-                else f"version_{trainer.logger.version}"
-            )
+            version = trainer.logger.version if isinstance(trainer.logger.version, str) else f"version_{trainer.logger.version}"
 
-            version, name = trainer.accelerator_backend.broadcast(
-                (version, trainer.logger.name)
-            )
+            version, name = trainer.accelerator_backend.broadcast((version, trainer.logger.name))
 
             ckpt_path = os.path.join(save_dir, str(name), version, "checkpoints")
         else:
@@ -486,9 +456,7 @@ class ModelCheckpointLastOnly(Callback):
 
         version_cnt = 0
         while self.file_exists(filepath, trainer) and filepath != del_filepath:
-            filepath = self.format_checkpoint_name(
-                epoch, step, ckpt_name_metrics, ver=version_cnt
-            )
+            filepath = self.format_checkpoint_name(epoch, step, ckpt_name_metrics, ver=version_cnt)
             version_cnt += 1
 
         return filepath
@@ -497,9 +465,7 @@ class ModelCheckpointLastOnly(Callback):
         ckpt_name_metrics = deepcopy(trainer.logger_connector.logged_metrics)
         ckpt_name_metrics.update(trainer.logger_connector.callback_metrics)
         ckpt_name_metrics.update(trainer.logger_connector.progress_bar_metrics)
-        ckpt_name_metrics.update(
-            {"step": trainer.global_step, "epoch": trainer.current_epoch}
-        )
+        ckpt_name_metrics.update({"step": trainer.global_step, "epoch": trainer.current_epoch})
         return ckpt_name_metrics
 
     def _save_last_checkpoint(self, trainer, pl_module):
@@ -516,9 +482,7 @@ class ModelCheckpointLastOnly(Callback):
                 # ckpt_name_metrics,
                 prefix=self.prefix,
             )
-            last_filepath = os.path.join(
-                self.dirpath, f"{last_filepath}{self.FILE_EXTENSION}"
-            )
+            last_filepath = os.path.join(self.dirpath, f"{last_filepath}{self.FILE_EXTENSION}")
         else:
             last_filepath = self._get_metric_interpolated_filepath_name(
                 # ckpt_name_metrics,
@@ -531,9 +495,7 @@ class ModelCheckpointLastOnly(Callback):
 
         if accelerator_backend is not None and accelerator_backend.rpc_enabled:
             # RPCPlugin manages saving all model states
-            accelerator_backend.ddp_plugin.rpc_save_model(
-                self._save_model, last_filepath, trainer, pl_module
-            )
+            accelerator_backend.ddp_plugin.rpc_save_model(self._save_model, last_filepath, trainer, pl_module)
         else:
             self._save_model(last_filepath, trainer, pl_module)
         if (
@@ -557,18 +519,12 @@ class ModelCheckpointLastOnly(Callback):
             if isinstance(current, Metric):
                 current = current.compute()
             elif isinstance(current, numbers.Number):
-                current = torch.tensor(
-                    current, device=pl_module.device, dtype=torch.float
-                )
+                current = torch.tensor(current, device=pl_module.device, dtype=torch.float)
 
         if self.check_monitor_top_k(current):
-            self._update_best_and_save(
-                current, epoch, step, trainer, pl_module, metrics
-            )
+            self._update_best_and_save(current, epoch, step, trainer, pl_module, metrics)
         elif self.verbose:
-            rank_zero_info(
-                f"Epoch {epoch:d}, step {step:d}: {self.monitor} was not in top {self.save_top_k}"
-            )
+            rank_zero_info(f"Epoch {epoch:d}, step {step:d}: {self.monitor} was not in top {self.save_top_k}")
 
     def _is_valid_monitor_key(self, metrics):
         return self.monitor in metrics or len(metrics) == 0
@@ -593,9 +549,7 @@ class ModelCheckpointLastOnly(Callback):
         if torch.isnan(current):
             current = torch.tensor(float("inf" if self.mode == "min" else "-inf"))
 
-        filepath = self._get_metric_interpolated_filepath_name(
-            ckpt_name_metrics, epoch, step, trainer, del_filepath
-        )
+        filepath = self._get_metric_interpolated_filepath_name(ckpt_name_metrics, epoch, step, trainer, del_filepath)
 
         # save the current score
         self.current_score = current
@@ -604,9 +558,7 @@ class ModelCheckpointLastOnly(Callback):
         if len(self.best_k_models) == k:
             # monitor dict has reached k elements
             _op = max if self.mode == "min" else min
-            self.kth_best_model_path = _op(
-                self.best_k_models, key=self.best_k_models.get
-            )
+            self.kth_best_model_path = _op(self.best_k_models, key=self.best_k_models.get)
             self.kth_value = self.best_k_models[self.kth_best_model_path]
 
         _op = min if self.mode == "min" else max

--- a/siampose/checkpointing.py
+++ b/siampose/checkpointing.py
@@ -16,7 +16,7 @@ import torch
 import yaml
 
 from pytorch_lightning.callbacks.base import Callback
-from pytorch_lightning.metrics.metric import Metric
+from torchmetrics import Metric
 from pytorch_lightning.utilities import rank_zero_info, rank_zero_only, rank_zero_warn
 from pytorch_lightning.utilities.cloud_io import get_filesystem
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
@@ -198,14 +198,14 @@ class ModelCheckpointLastOnly(Callback):
         # ):
         #    return
 
-        self._add_backward_monitor_support(trainer)
-        self._validate_monitor_key(trainer)
+        #self._add_backward_monitor_support(trainer)
+        # self._validate_monitor_key(trainer)
 
         # track epoch when ckpt was last checked
         self._last_global_step_saved = global_step
 
         # what can be monitored
-        monitor_candidates = self._monitor_candidates(trainer)
+        # monitor_candidates = self._monitor_candidates(trainer)
 
         # callback supports multiple simultaneous modes
         # here we call each mode sequentially
@@ -214,7 +214,7 @@ class ModelCheckpointLastOnly(Callback):
         #    self._save_top_k_checkpoints(trainer, pl_module, monitor_candidates)
 
         # Mode 2: save the last checkpoint
-        self._save_last_checkpoint(trainer, pl_module, monitor_candidates)
+        self._save_last_checkpoint(trainer, pl_module)
 
     def __validate_init_configuration(self):
         if self.save_top_k is not None and self.save_top_k < -1:
@@ -502,7 +502,7 @@ class ModelCheckpointLastOnly(Callback):
         )
         return ckpt_name_metrics
 
-    def _save_last_checkpoint(self, trainer, pl_module, ckpt_name_metrics):
+    def _save_last_checkpoint(self, trainer, pl_module):
         should_save_last = True  # We want to save!
         # if not should_save_last:
         #    return
@@ -513,7 +513,7 @@ class ModelCheckpointLastOnly(Callback):
                 self.CHECKPOINT_NAME_LAST,
                 trainer.current_epoch,
                 trainer.global_step,
-                ckpt_name_metrics,
+                # ckpt_name_metrics,
                 prefix=self.prefix,
             )
             last_filepath = os.path.join(
@@ -521,7 +521,7 @@ class ModelCheckpointLastOnly(Callback):
             )
         else:
             last_filepath = self._get_metric_interpolated_filepath_name(
-                ckpt_name_metrics,
+                # ckpt_name_metrics,
                 trainer.current_epoch,
                 trainer.global_step,
                 trainer,

--- a/siampose/data/classification/README.md
+++ b/siampose/data/classification/README.md
@@ -1,0 +1,31 @@
+# Generic File Based Classification Dataloader
+The goal is to provide a generic way to pre-train on unlabelled data from videos, then evaluate how well the embeddings for a never before seen image patch (for instance, object crop) maps to similar image patches.
+
+The underlying network architecture is the same as SimSiam. The motivation behind using siamese networks is to avoid having to define negative pairs. Instead of a contrastive architecture, we use an "attractive" architecture, which is more likely to work well with video data. 
+
+## Dataset Description
+### Training Set
+The training set will be split in a fully "unlabelled" training set, and a smaller "labelled" training set, which will be used for nearest neighbor lookup.
+
+The unlabelled dataset contains raw video frames, while the labelled training set contains object crops with their respective categories. 
+
+### Validation Set
+The validation set is a set of object crops with their respective categories. Those samples will be used a queries against the training set.  
+
+### Test Set
+Real world operation perfomance will be used as a test set. 
+
+# Downstream Tasks
+## Unsupervised pre-training
+During the unsupervised pre-training, overlapping crops from two consecutive videos frames are extratcted and used as a positive pair. Data augmentation is done on each crop to generate diversity. The underlying assumption is that overlapping crops will contain overlapping objects. 
+
+### Positive pairs
+The first strategy is to pick a random point on the first image. Assuming a 96x96 projector input size, we can take a random crop arround a location (x,y) of a bigger size, such as 224x196, then scale it back to 96x96. The size of the second crop should be taken arround the same location (x,y), but with a different size, such as 96x128. Again, the second crop would be resize to the 96x96 input size. This would in fact create a "random resized crop" arround a specific location, create a self-annotated "object" in the scene.  
+
+## Qualitative evaluation.
+For qualitative evaluation, the goal is to make sure that queries from the validation dataset will retrieve semantically similar objects in the training dataset. For instance, if a patch containing a "cow" is used as a query, and all/most of the resulting patches in the training sets also contain "cows", then it suggests that sementically similar objects are nearby in embedding space. 
+
+This can also be used a a tool to quickly annotate data in the training set, with a "human" confirming the proposals from the system. Qualitative evaluation does not require any labeled data.
+
+## Few-shot classification.
+In order to validate the few-shot classification performance, embeddings will be generated for the validation set object crops. A small "few-shot" labelled training set, which can overlap with the unsupervised dataset, will contain the category for object crops. Embeddings will also be generated for this labelled dataset, and a nearest neighbor lookup in embedding space will be used to find the closest sample. 

--- a/siampose/data/classification/README.md
+++ b/siampose/data/classification/README.md
@@ -4,6 +4,7 @@ The goal is to provide a generic way to pre-train on unlabelled data from videos
 The underlying network architecture is the same as SimSiam. The motivation behind using siamese networks is to avoid having to define negative pairs. Instead of a contrastive architecture, we use an "attractive" architecture, which is more likely to work well with video data. 
 
 ## Dataset Description
+
 ### Training Set
 The training set will be split in a fully "unlabelled" training set, and a smaller "labelled" training set, which will be used for nearest neighbor lookup.
 
@@ -13,14 +14,33 @@ The unlabelled dataset contains raw video frames, while the labelled training se
 The validation set is a set of object crops with their respective categories. Those samples will be used a queries against the training set.  
 
 ### Test Set
-Real world operation perfomance will be used as a test set. 
+Real world operation perfomance will be used as a test set.
+
+### Folder structure
+Labelled crops are only required for quantitative evaluation. 
+```
+.
+├── training
+│   ├── labelled_crops
+│   │   ├── category1
+│   │   └── category2
+│   └── unlabelled
+└── validation
+    └── labelled_crops
+        ├── category1
+        └── category2
+```
 
 # Downstream Tasks
 ## Unsupervised pre-training
 During the unsupervised pre-training, overlapping crops from two consecutive videos frames are extratcted and used as a positive pair. Data augmentation is done on each crop to generate diversity. The underlying assumption is that overlapping crops will contain overlapping objects. 
 
 ### Positive pairs
-The first strategy is to pick a random point on the first image. Assuming a 96x96 projector input size, we can take a random crop arround a location (x,y) of a bigger size, such as 224x196, then scale it back to 96x96. The size of the second crop should be taken arround the same location (x,y), but with a different size, such as 96x128. Again, the second crop would be resize to the 96x96 input size. This would in fact create a "random resized crop" arround a specific location, create a self-annotated "object" in the scene.  
+The first strategy is to pick a random point on the first image. Assuming a 96x96 projector input size, we can take a random crop arround a location (x,y) of a bigger size, such as 224x196, then scale it back to 96x96. The size of the second crop should be taken arround the same location (x,y), but with a different size, such as 96x128. Again, the second crop would be resize to the 96x96 input size. This would in fact create a "random resized crop" arround a specific location, create a self-annotated "object" in the scene.
+
+Other than that, the augmentation will be the same as in SimClr. https://arxiv.org/pdf/2002.05709.pdf
+
+This means that random color jitter and random gaussion blur will be used.
 
 ## Qualitative evaluation.
 For qualitative evaluation, the goal is to make sure that queries from the validation dataset will retrieve semantically similar objects in the training dataset. For instance, if a patch containing a "cow" is used as a query, and all/most of the resulting patches in the training sets also contain "cows", then it suggests that sementically similar objects are nearby in embedding space. 

--- a/siampose/data/classification/mjpeg.py
+++ b/siampose/data/classification/mjpeg.py
@@ -3,7 +3,7 @@ from re import I
 from pytest import param
 import torch
 import glob
-import os 
+import os
 from natsort import natsorted
 import cv2
 import os
@@ -15,53 +15,82 @@ import torchvision.transforms as T
 from torch.utils.data.dataloader import DataLoader
 from PIL import Image
 
+IMAGENET_MEAN_STD = [[0.485, 0.456, 0.406], [0.229, 0.224, 0.225]]
+
+
 class MjpegDataset(torch.utils.data.Dataset):
-    
-    def __init__(self, path: str, transform=None, single_image_mode=False, crop_height=224, crop_width=224, min_scale=0.6, max_scale=1.6, only_crops=True) -> None:
-        self.unlabelled_files = natsorted(glob.glob(os.path.join(path, "unlabelled/*.jpg")))
+    def __init__(
+        self,
+        path: str,
+        transform=None,
+        single_image_mode=False,
+        crop_height=224,
+        crop_width=224,
+        min_scale=0.6,
+        max_scale=1.6,
+        only_crops=True,
+        include_labelled=False,
+        labelled_only=False,
+    ) -> None:
+        if labelled_only:
+            self.unlabelled_files = []
+        else:
+            self.unlabelled_files = natsorted(glob.glob(os.path.join(path, "unlabelled/*.jpg")))
+        self.files = []
+        self.labelled_files = {}
+        if include_labelled:
+            for folder in natsorted(glob.glob(os.path.join(path, "*"))):
+                if os.path.isdir(folder):
+                    category = folder.split("/")[-1]
+                    if category == "unlabelled":
+                        continue
+                    self.labelled_files[category] = natsorted(glob.glob(os.path.join(path, f"{category}/*.jpg")))
+
         self.single_image_mode = single_image_mode
         self.file_map = {}
         self.crop_width, self.crop_height = crop_width, crop_height
         self.min_scale = min_scale
         self.max_scale = max_scale
         self.only_crops = only_crops
+        # self.labelled_only = labelled_only
+        self._build_index()
         self._build_sequence_id_map()
         self._build_file_map()
+
         self.transform = transform
 
-    def random_video_crop(self,img, xc, yc):
+    def _build_index(self):
+        self.files = self.unlabelled_files
+        for category in self.labelled_files:
+            self.files += self.labelled_files[category]
+
+    def random_video_crop(self, img, xc, yc):
         if not isinstance(img, np.ndarray):
             h, w = img.height, img.width
         else:
-            h, w, _= img.shape
-        crop_w = int(np.clip(np.random.uniform(self.crop_width*self.min_scale, self.crop_width*self.max_scale), 0, h))
-        crop_h = int(np.clip(np.random.uniform(self.crop_height*self.min_scale, self.crop_height*self.max_scale), 0, w))
-        x1, y1 = int(np.clip(xc-crop_w/2, 0, w-1)), int(np.clip(yc-crop_h/2, 0, h-1))
-        x2, y2 = int(np.clip(xc+crop_w/2, 0, w-1)), int(np.clip(yc+crop_h/2, 0, h-1))
+            h, w, _ = img.shape
+        crop_w = int(np.clip(np.random.uniform(self.crop_width * self.min_scale, self.crop_width * self.max_scale), 0, h))
+        crop_h = int(np.clip(np.random.uniform(self.crop_height * self.min_scale, self.crop_height * self.max_scale), 0, w))
+        x1, y1 = int(np.clip(xc - crop_w / 2, 0, w - 1)), int(np.clip(yc - crop_h / 2, 0, h - 1))
+        x2, y2 = int(np.clip(xc + crop_w / 2, 0, w - 1)), int(np.clip(yc + crop_h / 2, 0, h - 1))
         if isinstance(img, np.ndarray):
-            crop = img[y1:y2,x1:x2]
-        else: # Assume Pillow Image
+            crop = img[y1:y2, x1:x2]
+        else:  # Assume Pillow Image
             img: Image.Image
-            crop = img.crop([x1,y1, x2, y2])
+            crop = img.crop([x1, y1, x2, y2])
         return crop
 
     def __len__(self):
-        return len(self.unlabelled_files)
+        return len(self.files)
 
     def _build_sequence_id_map(self):
-        self.sequence_id_map={}
-        for file in self.unlabelled_files:
+        self.sequence_id_map = {}
+        for file in self.files:
             sequence_id = self._get_sequence_id(file)
             if sequence_id not in self.sequence_id_map:
                 self.sequence_id_map[sequence_id] = [file]
             else:
                 self.sequence_id_map[sequence_id].append(file)
-    
-    def _fast_read(self, filename):
-        assert False
-        img = cv2.imread(filename)
-        img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-        return img_rgb
 
     def _build_file_map(self):
         self.file_map = {}
@@ -73,64 +102,80 @@ class MjpegDataset(torch.utils.data.Dataset):
                 "sequence_id": sequence_id,
                 "frame_number": self._get_frame_number(file),
                 "frame_index": self.sequence_id_map[sequence_id].index(file),
-                "idx": idx
+                "idx": idx,
             }
+
     def _get_sequence_id(self, filename):
         basename = os.path.basename(filename)
-        sequence_id = "_".join(basename.split("_")[0:-1])
+        category = self._get_category(filename)
+        if category == "unlabelled":
+            sequence_id = "_".join(basename.split("_")[0:-1])
+        else:  # Remove the "object ID" also
+            sequence_id = "_".join(basename.split("_")[0:-2])
         return sequence_id
 
     def _get_frame_number(self, filename):
         basename = os.path.basename(filename)
-        frame_number = basename.split("_")[-1].replace(".jpg","")
+        category = self._get_category(filename)
+        if category == "unlabelled":
+            frame_number = basename.split("_")[-1].replace(".jpg", "")
+        else:  # Remove the "object ID" also
+            frame_number = basename.split("_")[-2].replace(".jpg", "")
+
         return int(frame_number)
 
     def get_single_item(self, idx):
-        filename = self.unlabelled_files[idx]
+        filename = self.files[idx]
         return self.get_single_file(filename)
 
     def get_single_file(self, filename):
-        #img = self._fast_read(filename)
+        # img = self._fast_read(filename)
         img = Image.open(filename)
         sample = {
-            "image" : img,
+            "image": img,
             "sequence": self._get_sequence_id(filename),
             "path": filename,
-            "frame_numer": self._get_frame_number(filename)
+            "frame_numer": self._get_frame_number(filename),
+            "category": self._get_category(filename),
         }
         return sample
 
+    def _get_category(self, filename):
+        return filename.split("/")[-2]
+
     def get_frame_index(self, filename):
         basename = os.path.basename(filename)
-        frame_index= self.file_map[basename]["frame_index"]
+        frame_index = self.file_map[basename]["frame_index"]
         return frame_index
 
     def _get_nearby_frame_index(self, filename, min_dist=1, max_dist=5, both_ways=True):
         basename = os.path.basename(filename)
-        frame_index= self.file_map[basename]["frame_index"]
+        frame_index = self.file_map[basename]["frame_index"]
         gap = random.randint(min_dist, max_dist)
         sequence_id = self._get_sequence_id(filename)
         if both_ways and random.random() > 0.5:
             gap = -gap
-        assert gap!=0
-        last_index = len(self.sequence_id_map[sequence_id])-1
-        nearby_frame_index = np.clip(frame_index+gap, 1, last_index)
-        if nearby_frame_index==frame_index:
-            nearby_frame_index = np.clip(frame_index-gap, 1, last_index)
-        return nearby_frame_index 
+        assert gap != 0
+        last_index = len(self.sequence_id_map[sequence_id]) - 1
+        nearby_frame_index = np.clip(frame_index + gap, 1, last_index)
+        if nearby_frame_index == frame_index:
+            nearby_frame_index = np.clip(frame_index - gap, 1, last_index)
+        return nearby_frame_index
 
     @property
     def seq_subset(self):
         return natsorted(list(self.sequence_id_map))
 
     def random_normal_center(self, w, h, std_dev=3):
-        xc = int(np.clip(np.random.normal(w/2, w/std_dev), 0, w-1))
-        yc = int(np.clip(np.random.normal(h/2, h/std_dev), 0, h-1))
+        xc = int(np.clip(np.random.normal(w / 2, w / std_dev), 0, w - 1))
+        yc = int(np.clip(np.random.normal(h / 2, h / std_dev), 0, h - 1))
         return xc, yc
 
     def __getitem__(self, idx):
         base_sample = self.get_single_item(idx)
         if self.single_image_mode:
+            if self.transform:
+                base_sample["image"] = self.transform(base_sample["image"])
             return base_sample
         else:
             # Crop pairs!
@@ -138,7 +183,7 @@ class MjpegDataset(torch.utils.data.Dataset):
 
             img1 = sample["image"]
             if isinstance(img1, np.ndarray):
-                h, w, c= img1.shape
+                h, w, c = img1.shape
             else:
                 img1: Image.Image
                 h, w = img1.height, img1.width
@@ -148,15 +193,15 @@ class MjpegDataset(torch.utils.data.Dataset):
             nearby_filename = self.sequence_id_map[sample["sequence"]][nearby_index]
             img2 = Image.open(nearby_filename)
             crop2 = self.random_video_crop(img2, xc, yc)
-            crops =[crop1, crop2]
+            crops = [crop1, crop2]
             if self.transform:
                 crops = [self.transform(crop) for crop in crops]
-            assert len(crops)==2
+            assert len(crops) == 2
             sample["crops"] = crops
             if self.only_crops:
                 del sample["image"]
             return sample
-IMAGENET_MEAN_STD = [[0.485, 0.456, 0.406], [0.229, 0.224, 0.225]]
+
 
 class MjpegDataModule(pytorch_lightning.LightningDataModule):
     def __init__(
@@ -167,6 +212,7 @@ class MjpegDataModule(pytorch_lightning.LightningDataModule):
         num_workers=8,
         pairing="next",
         dryrun=False,
+        labelled_only=False,  # Usefull when generating embeddings
     ):
         super().__init__()
         self.data_dir = data_dir
@@ -180,9 +226,7 @@ class MjpegDataModule(pytorch_lightning.LightningDataModule):
     def setup(self, stage=None):
         if not self.issetup:
             self.train_transform = self.get_transform(self.image_size)
-            self.eval_transform = self.get_transform(
-                self.image_size, evaluation=True
-            )
+            self.eval_transform = self.get_transform(self.image_size, evaluation=True)
             self.train_dataset = MjpegDataset(
                 os.path.join(self.data_dir, "training"),
                 transform=self.train_transform,
@@ -199,44 +243,40 @@ class MjpegDataModule(pytorch_lightning.LightningDataModule):
             self.valid_sample_count = len(self.val_dataset)
             self.issetup = True
 
-
-    def get_transform(
-        self, image_size, mean_std=IMAGENET_MEAN_STD, evaluation=False
-    ):
+    def get_transform(self, image_size, mean_std=IMAGENET_MEAN_STD, evaluation=False):
         if not evaluation:
             # hflip = T.RandomHorizontalFlip()
             p_blur = 0.5 if image_size > 32 else 0
             transform_list = [
                 # T.RandomResizedCrop(image_size, scale=(0.2, 1.0)),
                 # hflip,
-                # 
-                T.Resize((image_size,image_size)),
+                #
+                T.Resize((image_size, image_size)),
                 T.RandomApply([T.ColorJitter(0.4, 0.4, 0.4, 0.1)], p=0.8),
                 T.RandomGrayscale(p=0.2),
                 T.RandomApply(
-                    [
-                        T.GaussianBlur(
-                            kernel_size=image_size // 20 * 2 + 1, sigma=(0.1, 2.0)
-                        )
-                    ],
+                    [T.GaussianBlur(kernel_size=image_size // 20 * 2 + 1, sigma=(0.1, 2.0))],
                     p=p_blur,
                 ),
                 T.ToTensor(),
                 T.Normalize(*mean_std),
-                
             ]
             return T.Compose(transform_list)
         else:
-            return T.Compose([  T.Resize((image_size,image_size)), T.ToTensor(), T.Normalize(*mean_std), ])
+            return T.Compose(
+                [
+                    T.Resize((image_size, image_size)),
+                    T.ToTensor(),
+                    T.Normalize(*mean_std),
+                ]
+            )
 
     def train_dataloader(self, evaluation=False) -> DataLoader:
         self.train_dataset.transform = self.train_transform
         if evaluation:
             self.train_dataset.transform = self.eval_transform
             self.train_dataset.memory = True  # Avoid horizontal flip for evaluation.
-        if (
-            self.dryrun
-        ):  # Just to quickly test the training loop. Trains on "test set", validation on valid set.
+        if self.dryrun:  # Just to quickly test the training loop. Trains on "test set", validation on valid set.
             print("WARNING: DRY RUN. Not performing real training.")
             return self.test_dataloader()
         return DataLoader(
@@ -258,6 +298,4 @@ class MjpegDataModule(pytorch_lightning.LightningDataModule):
         )
 
     def test_dataloader(self) -> DataLoader:
-        return DataLoader(
-            self.test_dataset, batch_size=self.batch_size, num_workers=self.num_workers
-        )
+        return DataLoader(self.test_dataset, batch_size=self.batch_size, num_workers=self.num_workers)

--- a/siampose/data/classification/mjpeg.py
+++ b/siampose/data/classification/mjpeg.py
@@ -1,0 +1,240 @@
+# Motion JPEG dataloader. Allows reading motion JPEG videos as unlabelled data.
+from pytest import param
+import torch
+import glob
+import os 
+from natsort import natsorted
+import cv2
+import os
+from tqdm import tqdm
+import random
+import numpy as np
+import pytorch_lightning
+import torchvision.transforms as T
+from torch.utils.data.dataloader import DataLoader
+
+class MjpegDataset(torch.utils.data.Dataset):
+    
+    def __init__(self, path: str, transform=None, single_image_mode=False, crop_height=224, crop_width=224, min_scale=0.6, max_scale=1.6) -> None:
+        self.unlabelled_files = natsorted(glob.glob(os.path.join(path, "unlabelled/*.jpg")))
+        self.single_image_mode = single_image_mode
+        self.file_map = {}
+        self.crop_width, self.crop_height = crop_width, crop_height
+        self.min_scale = min_scale
+        self.max_scale = max_scale
+        self._build_sequence_id_map()
+        self._build_file_map()
+        self.transform = transform
+
+    def random_video_crop(self,img, xc, yc):
+        h, w, _= img.shape
+        crop_w = int(np.clip(np.random.uniform(self.crop_width*self.min_scale, self.crop_width*self.max_scale), 0, h))
+        crop_h = int(np.clip(np.random.uniform(self.crop_height*self.min_scale, self.crop_height*self.max_scale), 0, w))
+        x1, y1 = int(np.clip(xc-crop_w/2, 0, w-1)), int(np.clip(yc-crop_h/2, 0, h-1))
+        x2, y2 = int(np.clip(xc+crop_w/2, 0, w-1)), int(np.clip(yc+crop_h/2, 0, h-1))
+        crop = img[y1:y2,x1:x2]
+        return crop
+
+    def __len__(self):
+        return len(self.unlabelled_files)
+
+    def _build_sequence_id_map(self):
+        self.sequence_id_map={}
+        for file in self.unlabelled_files:
+            sequence_id = self._get_sequence_id(file)
+            if sequence_id not in self.sequence_id_map:
+                self.sequence_id_map[sequence_id] = [file]
+            else:
+                self.sequence_id_map[sequence_id].append(file)
+    def _fast_read(self, filename):
+        img = cv2.imread(filename)
+        img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        return img_rgb
+
+    def _build_file_map(self):
+        self.file_map = {}
+        for idx, file in enumerate(tqdm(self.unlabelled_files)):
+            basename = os.path.basename(file)
+            sequence_id = self._get_sequence_id(file)
+            self.file_map[basename] = {
+                "file": file,
+                "sequence_id": sequence_id,
+                "frame_number": self._get_frame_number(file),
+                "frame_index": self.sequence_id_map[sequence_id].index(file),
+                "idx": idx
+            }
+    def _get_sequence_id(self, filename):
+        basename = os.path.basename(filename)
+        sequence_id = "_".join(basename.split("_")[0:-1])
+        return sequence_id
+
+    def _get_frame_number(self, filename):
+        basename = os.path.basename(filename)
+        frame_number = basename.split("_")[-1].replace(".jpg","")
+        return int(frame_number)
+
+    def get_single_item(self, idx):
+        filename = self.unlabelled_files[idx]
+        return self.get_single_file(filename)
+
+    def get_single_file(self, filename):
+        img = self._fast_read(filename)
+        sample = {
+            "image" : img,
+            "sequence": self._get_sequence_id(filename),
+            "path": filename,
+            "frame_numer": self._get_frame_number(filename)
+        }
+        return sample
+
+    def get_frame_index(self, filename):
+        basename = os.path.basename(filename)
+        frame_index= self.file_map[basename]["frame_index"]
+        return frame_index
+
+    def _get_nearby_frame_index(self, filename, min_dist=1, max_dist=5, both_ways=True):
+        basename = os.path.basename(filename)
+        frame_index= self.file_map[basename]["frame_index"]
+        gap = random.randint(min_dist, max_dist)
+        sequence_id = self._get_sequence_id(filename)
+        if both_ways and random.random() > 0.5:
+            gap = -gap
+        assert gap!=0
+        last_index = len(self.sequence_id_map[sequence_id])-1
+        nearby_frame_index = np.clip(frame_index+gap, 1, last_index)
+        if nearby_frame_index==frame_index:
+            nearby_frame_index = np.clip(frame_index-gap, 1, last_index)
+        return nearby_frame_index 
+
+    @param
+    def seq_subset(self):
+        return natsorted(list(self.sequence_id_map))
+
+    def random_normal_center(self, w, h, std_dev=3):
+        xc = int(np.clip(np.random.normal(w/2, w/std_dev), 0, w-1))
+        yc = int(np.clip(np.random.normal(h/2, h/std_dev), 0, h-1))
+        return xc, yc
+
+    def __getitem__(self, idx):
+        base_sample = self.get_single_item(idx)
+        if self.single_image_mode:
+            return base_sample
+        else:
+            # Crop pairs!
+            sample = base_sample
+            img1 = sample["image"]
+            h, w, c= img1.shape
+            xc, yc = self.random_normal_center(w, h)
+            crop1 = self.random_video_crop(img1, xc, yc)
+            nearby_index = self._get_nearby_frame_index(sample["path"])
+            nearby_filename = self.sequence_id_map[sample["sequence"]][nearby_index]
+            img2 = self._fast_read(nearby_filename)
+            crop2 = self.random_video_crop(img2, xc, yc)
+            crops = (crop1, crop2)
+            if self.transform:
+                crops = [self.transform(crop) for crop in crops]
+            sample["crops"] = crops
+            return sample
+IMAGENET_MEAN_STD = [[0.485, 0.456, 0.406], [0.229, 0.224, 0.225]]
+
+class MjpegDataModule(pytorch_lightning.LightningDataModule):
+    def __init__(
+        self,
+        data_dir,
+        batch_size=512,
+        image_size=224,
+        num_workers=6,
+        pairing="next",
+        dryrun=False,
+    ):
+        super().__init__()
+        self.data_dir = data_dir
+        self.batch_size = batch_size
+        self.image_size = image_size
+        self.issetup = False
+        self.num_workers = num_workers
+        self.pairing = pairing
+        self.dryrun = dryrun
+
+    def setup(self, stage=None):
+        if not self.issetup:
+            self.train_transform = self.get_transform(self.image_size)
+            self.eval_transform = self.get_transform(
+                self.image_size, evaluation=True
+            )
+            self.train_dataset = MjpegDataset(
+                os.path.join(self.data_dir, "training"),
+                transform=self.train_transform,
+            )
+            self.val_dataset = MjpegDataset(
+                os.path.join(self.data_dir, "validation"),
+                transform=self.eval_transform,
+            )
+            self.test_dataset = MjpegDataset(
+                os.path.join(self.data_dir, "test"),
+                transform=self.eval_transform,
+            )
+            self.train_sample_count = len(self.train_dataset)
+            self.valid_sample_count = len(self.val_dataset)
+            self.issetup = True
+
+
+    def get_transform(
+        self, image_size, mean_std=IMAGENET_MEAN_STD, evaluation=False
+    ):
+        if not evaluation:
+            # hflip = T.RandomHorizontalFlip()
+            p_blur = 0.5 if image_size > 32 else 0
+            transform_list = [
+                # T.RandomResizedCrop(image_size, scale=(0.2, 1.0)),
+                # hflip,
+                T.ToTensor(),
+                T.Resize((image_size,image_size)),
+                T.RandomApply([T.ColorJitter(0.4, 0.4, 0.4, 0.1)], p=0.8),
+                T.RandomGrayscale(p=0.2),
+                T.RandomApply(
+                    [
+                        T.GaussianBlur(
+                            kernel_size=image_size // 20 * 2 + 1, sigma=(0.1, 2.0)
+                        )
+                    ],
+                    p=p_blur,
+                ),
+                T.Normalize(*mean_std),
+            ]
+            return T.Compose(transform_list)
+        else:
+            return T.Compose([ T.ToTensor(), T.Resize((image_size,image_size)), T.Normalize(*mean_std)])
+
+    def train_dataloader(self, evaluation=False) -> DataLoader:
+        self.train_dataset.transform = self.train_transform
+        if evaluation:
+            self.train_dataset.transform = self.eval_transform
+            self.train_dataset.memory = True  # Avoid horizontal flip for evaluation.
+        if (
+            self.dryrun
+        ):  # Just to quickly test the training loop. Trains on "test set", validation on valid set.
+            print("WARNING: DRY RUN. Not performing real training.")
+            return self.test_dataloader()
+        return DataLoader(
+            self.train_dataset,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            shuffle=True,
+        )
+
+    def val_dataloader(self, evaluation=False) -> DataLoader:
+        self.val_dataset.memory = False
+        if evaluation:
+            self.val_dataset.memory = True  # Avoid horizontal flip for evaluation.
+        return DataLoader(
+            self.val_dataset,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            shuffle=True,
+        )
+
+    def test_dataloader(self) -> DataLoader:
+        return DataLoader(
+            self.test_dataset, batch_size=self.batch_size, num_workers=self.num_workers
+        )

--- a/siampose/data/classification/mjpeg.py
+++ b/siampose/data/classification/mjpeg.py
@@ -212,7 +212,7 @@ class MjpegDataModule(pytorch_lightning.LightningDataModule):
         num_workers=8,
         pairing="next",
         dryrun=False,
-        labelled_only=False,  # Usefull when generating embeddings
+        generate_embeddings=False,  # Usefull when generating embeddings
     ):
         super().__init__()
         self.data_dir = data_dir
@@ -222,23 +222,44 @@ class MjpegDataModule(pytorch_lightning.LightningDataModule):
         self.num_workers = num_workers
         self.pairing = pairing
         self.dryrun = dryrun
+        self.generate_embeddings = generate_embeddings
 
     def setup(self, stage=None):
         if not self.issetup:
             self.train_transform = self.get_transform(self.image_size)
             self.eval_transform = self.get_transform(self.image_size, evaluation=True)
-            self.train_dataset = MjpegDataset(
-                os.path.join(self.data_dir, "training"),
-                transform=self.train_transform,
-            )
-            self.val_dataset = MjpegDataset(
-                os.path.join(self.data_dir, "validation"),
-                transform=self.eval_transform,
-            )
-            self.test_dataset = MjpegDataset(
-                os.path.join(self.data_dir, "test"),
-                transform=self.eval_transform,
-            )
+            if not self.generate_embeddings:
+                self.train_dataset = MjpegDataset(
+                    os.path.join(self.data_dir, "training"),
+                    transform=self.train_transform,
+                )
+                self.val_dataset = MjpegDataset(
+                    os.path.join(self.data_dir, "validation"),
+                    transform=self.eval_transform,
+                )
+                self.test_dataset = MjpegDataset(
+                    os.path.join(self.data_dir, "test"),
+                    transform=self.eval_transform,
+                )
+            else:
+                self.train_dataset = MjpegDataset(
+                    os.path.join(self.data_dir, "training"),
+                    transform=self.train_transform,
+                    labelled_only=True,
+                    single_image_mode=True,
+                )
+                self.val_dataset = MjpegDataset(
+                    os.path.join(self.data_dir, "validation"),
+                    transform=self.eval_transform,
+                    labelled_only=True,
+                    single_image_mode=True,
+                )
+                self.test_dataset = MjpegDataset(
+                    os.path.join(self.data_dir, "test"),
+                    transform=self.eval_transform,
+                    labelled_only=True,
+                    single_image_mode=True,
+                )
             self.train_sample_count = len(self.train_dataset)
             self.valid_sample_count = len(self.val_dataset)
             self.issetup = True

--- a/siampose/data/objectron/file_datamodule.py
+++ b/siampose/data/objectron/file_datamodule.py
@@ -11,9 +11,9 @@ import pytorch_lightning
 import typing
 from torch.utils.data.dataloader import DataLoader
 
-imagenet_mean_std = [[0.485, 0.456, 0.406], [0.229, 0.224, 0.225]]
+IMAGENET_MEAN_STD = [[0.485, 0.456, 0.406], [0.229, 0.224, 0.225]]
 import torchvision.transforms as T
-from torchvision.transforms.transforms import RandomResizedCrop, Scale
+from torchvision.transforms.transforms import RandomResizedCrop, Resize
 
 
 @concurrent
@@ -353,7 +353,7 @@ class ObjectronFileDataModule(pytorch_lightning.LightningDataModule):
             # self.seq_subset = self.sequence_list
 
     def get_objectron_transform(
-        self, image_size, mean_std=imagenet_mean_std, evaluation=False
+        self, image_size, mean_std=IMAGENET_MEAN_STD, evaluation=False
     ):
         if not evaluation:
             # hflip = T.RandomHorizontalFlip()

--- a/siampose/main.py
+++ b/siampose/main.py
@@ -7,7 +7,7 @@ import shutil
 import sys
 from typing import OrderedDict
 from torch.nn.modules.linear import Identity
-from traitlets.traitlets import default
+#from traitlets.traitlets import default
 import yaml
 
 import mlflow
@@ -15,6 +15,7 @@ from yaml import load
 import pytorch_lightning as pl
 from pytorch_lightning.loggers import MLFlowLogger, TensorBoardLogger
 
+from siampose.data.classification.mjpeg import MjpegDataModule
 from siampose.train import train, load_mlflow, STAT_FILE_NAME
 from siampose.utils.hp_utils import check_and_log_hp
 from siampose.models.model_loader import load_model
@@ -201,7 +202,7 @@ def run(args, data_dir, output_dir, hyper_params, mlf_logger, tbx_logger):
         hyper_params,
     )
 
-    if hyper_params["seed"] is not None:
+    if hyper_params["seed"] is not None and hyper_params["seed"]!="None":
         set_seed(hyper_params["seed"])
 
     if "precision" not in hyper_params:
@@ -260,6 +261,9 @@ def run(args, data_dir, output_dir, hyper_params, mlf_logger, tbx_logger):
             dryrun=args.dryrun,
         )
         dm.setup()  # In order to have the sample count.
+    elif args.data_module=="mjpeg":
+        dm = MjpegDataModule(data_dir=data_dir, batch_size=hyper_params["batch_size"])
+        dm.setup()
 
     # se
 

--- a/siampose/main.py
+++ b/siampose/main.py
@@ -262,7 +262,7 @@ def run(args, data_dir, output_dir, hyper_params, mlf_logger, tbx_logger):
         )
         dm.setup()  # In order to have the sample count.
     elif args.data_module=="mjpeg":
-        dm = MjpegDataModule(data_dir=data_dir, batch_size=hyper_params["batch_size"])
+        dm = MjpegDataModule(data_dir=data_dir, batch_size=hyper_params["batch_size"], num_workers=hyper_params["num_workers"])
         dm.setup()
 
     # se

--- a/siampose/train.py
+++ b/siampose/train.py
@@ -23,10 +23,7 @@ def train(**kwargs):  # pragma: no cover
     except RuntimeError as err:
         if orion.client.cli.IS_ORION_ON and "CUDA out of memory" in str(err):
             logger.error(err)
-            logger.error(
-                "model was out of memory - assigning a bad score to tell Orion to avoid"
-                "too big model"
-            )
+            logger.error("model was out of memory - assigning a bad score to tell Orion to avoid" "too big model")
             best_dev_metric = -999
         else:
             raise err
@@ -100,14 +97,16 @@ def train_impl(
             verbose=use_progress_bar,
             mode="auto",
         )
-        best_checkpoint_callback = pl.callbacks.ModelCheckpoint(
+        checkpoints_callback = pl.callbacks.ModelCheckpoint(
             dirpath=output,
+            save_last=True,
+            every_n_epochs=10,
             filename="best-{epoch}-{step}",
             monitor=hyper_params["early_stop_metric"],
             verbose=use_progress_bar,
             mode="auto",
         )
-        callbacks.extend([early_stopping, best_checkpoint_callback])
+        callbacks.extend([early_stopping, checkpoints_callback])
 
     callbacks.extend(
         [
@@ -125,8 +124,8 @@ def train_impl(
         gpus=torch.cuda.device_count(),
         auto_select_gpus=True,
         precision=hyper_params["precision"],
-        #amp_backend="apex",
-        #amp_level="O1",
+        # amp_backend="apex",
+        # amp_level="O1",
         accelerator=None,
         accumulate_grad_batches=hyper_params.get("accumulate_grad_batches", 1),
     )

--- a/siampose/train.py
+++ b/siampose/train.py
@@ -112,16 +112,6 @@ def train_impl(
     callbacks.extend(
         [
             pl_bolts.callbacks.PrintTableMetricsCallback(),
-            ModelCheckpointLastOnly(
-                dirpath=output,
-                filename="last-{epoch}-{step}",
-                # verbose=use_progress_bar,
-                # monitor=hyper_params["early_stop_metric"],
-                # mode="max", #We have to hack arround to save the last checkpoint apparently!
-                verbose=True,
-                # save_top_k=3, #Just make sure that we save the last checkpoint.
-                # save_last=True,
-            ),
         ]
     )
 
@@ -135,7 +125,8 @@ def train_impl(
         gpus=torch.cuda.device_count(),
         auto_select_gpus=True,
         precision=hyper_params["precision"],
-        amp_level="O1",
+        #amp_backend="apex",
+        #amp_level="O1",
         accelerator=None,
         accumulate_grad_batches=hyper_params.get("accumulate_grad_batches", 1),
     )

--- a/test/test_mjpeg_dataloader.py
+++ b/test/test_mjpeg_dataloader.py
@@ -1,0 +1,93 @@
+from siampose.data.classification.mjpeg import MjpegDataset, MjpegDataModule
+import numpy as np
+import torch
+import os
+import cv2
+
+INTERACTIVE=False
+def test_test():
+    assert True
+
+
+def test_random_video_crop():
+    dataset = MjpegDataset("test/data/mjpeg/training", single_image_mode=True)
+    img = dataset[0]["image"]
+    h, w , c = img.shape
+    crop = dataset.random_video_crop(img, w//2, h//2)
+    crop_h, crop_w, _ = crop.shape
+    assert dataset.min_scale*crop_w < crop_w < dataset.max_scale*crop_w
+    assert dataset.min_scale*crop_h < crop_h < dataset.max_scale*crop_h
+
+def test_dataset_get_sequence_id_and_frame_number():
+    dataset = MjpegDataset("test/data/mjpeg/training", single_image_mode=True)
+    sequence_id = dataset._get_sequence_id("long_sequence_name_00005.jpg")
+    assert sequence_id =="long_sequence_name"
+    frame_number = dataset._get_frame_number("some_string_with_underscores_12345.jpg")
+    assert frame_number == 12345
+
+def test_get_nearby_frame_index():
+    dataset = MjpegDataset("test/data/mjpeg/training", single_image_mode=True)
+    filename = "test/data/mjpeg/training/unlabelled/20210723_172608_031446.jpg"
+    idx = dataset.get_frame_index(filename)
+    seq_id = dataset._get_sequence_id(filename)
+    nearby_idx = dataset._get_nearby_frame_index("test/data/mjpeg/training/unlabelled/20210723_172608_031446.jpg", min_dist=1, max_dist=1)
+    assert idx!=nearby_idx
+    assert abs(idx-nearby_idx) <=1
+    assert dataset.sequence_id_map[seq_id][dataset.get_frame_index(filename)]==filename
+
+def test_dataset_unlabelled_single_mode():
+    dataset = MjpegDataset("test/data/mjpeg/training", single_image_mode=True)
+    assert len(dataset.unlabelled_files) > 0
+    assert len(dataset) == 11
+    assert "image" in dataset[0]
+    assert "sequence" in dataset[0]
+    assert dataset[0]["sequence"] == "20210723_172608"
+    assert os.path.basename(dataset[0]["path"])!= dataset[0]["path"]
+    assert len(dataset.sequence_id_map)==4
+    assert len(dataset.file_map) == len(dataset)
+
+    for sample in dataset:
+        assert "image" in sample
+        assert isinstance(sample["image"], np.ndarray)
+        if INTERACTIVE:
+            cv2.imshow("test", sample["image"])
+            cv2.waitKey(1)
+import torchvision.transforms as transforms
+
+def test_dataset_unlabelled():
+
+    dataset = MjpegDataset("test/data/mjpeg/training", transform=None)
+    assert len(dataset.unlabelled_files) > 0
+    assert len(dataset) == 11
+    sample = dataset[0]
+    assert "image" in sample
+    assert "sequence" in sample
+    assert "crops" in sample
+    crop1, crop2 =  sample["crops"]
+    assert crop1.shape != crop2.shape
+    assert isinstance(crop1, np.ndarray)
+    transform = transforms.Compose([
+         transforms.ToTensor(),
+         transforms.Resize((224,224)),
+    ])
+    dataset = MjpegDataset("test/data/mjpeg/training", transform=transform)
+    assert isinstance(dataset.seq_subset, list)
+    assert len(dataset.seq_subset) > 0
+    assert isinstance(dataset.seq_subset[0], str)
+    sample = dataset[0]
+    crop1, crop2 =  sample["crops"]
+    assert isinstance(crop1, torch.Tensor)
+    assert crop1.shape==crop2.shape
+    assert crop1.shape==(3, 224,224)
+
+
+
+def test_mjpeg_data_module():
+    dm = MjpegDataModule("test/data/mjpeg")
+    dm.setup()
+    assert dm is not None
+    for sample in dm.train_dataset:
+        assert sample["crops"] is not None
+    dataloader = dm.train_dataloader()
+    for sample in dataloader:
+        assert sample["crops"] is not None

--- a/test/test_mjpeg_dataloader.py
+++ b/test/test_mjpeg_dataloader.py
@@ -1,11 +1,17 @@
 from calendar import c
+from multiprocessing.context import assert_spawning
+
+from pytest import skip
 from siampose.data.classification.mjpeg import MjpegDataset, MjpegDataModule
 import numpy as np
 import torch
 import os
 import cv2
 from PIL import Image
-INTERACTIVE=False
+
+INTERACTIVE = False
+
+
 def test_test():
     assert True
 
@@ -16,32 +22,37 @@ def test_random_video_crop():
     if not isinstance(img, np.ndarray):
         h, w = img.height, img.width
     else:
-        h, w , c = img.shape
-    crop = dataset.random_video_crop(img, w//2, h//2)
+        h, w, c = img.shape
+    crop = dataset.random_video_crop(img, w // 2, h // 2)
     if not isinstance(img, np.ndarray):
         crop_w, crop_h = crop.width, crop.height
     else:
         crop_h, crop_w, _ = crop.shape
-        
-    assert dataset.min_scale*crop_w < crop_w < dataset.max_scale*crop_w
-    assert dataset.min_scale*crop_h < crop_h < dataset.max_scale*crop_h
+
+    assert dataset.min_scale * crop_w < crop_w < dataset.max_scale * crop_w
+    assert dataset.min_scale * crop_h < crop_h < dataset.max_scale * crop_h
+
 
 def test_dataset_get_sequence_id_and_frame_number():
     dataset = MjpegDataset("test/data/mjpeg/training", single_image_mode=True)
-    sequence_id = dataset._get_sequence_id("long_sequence_name_00005.jpg")
-    assert sequence_id =="long_sequence_name"
-    frame_number = dataset._get_frame_number("some_string_with_underscores_12345.jpg")
+    sequence_id = dataset._get_sequence_id("unlabelled/long_sequence_name_00005.jpg")
+    assert sequence_id == "long_sequence_name"
+    frame_number = dataset._get_frame_number("bogus_category/some_string_with_underscores_12345_6.jpg")
     assert frame_number == 12345
+
 
 def test_get_nearby_frame_index():
     dataset = MjpegDataset("test/data/mjpeg/training", single_image_mode=True)
     filename = "test/data/mjpeg/training/unlabelled/20210723_172608_031446.jpg"
     idx = dataset.get_frame_index(filename)
     seq_id = dataset._get_sequence_id(filename)
-    nearby_idx = dataset._get_nearby_frame_index("test/data/mjpeg/training/unlabelled/20210723_172608_031446.jpg", min_dist=1, max_dist=1)
-    assert idx!=nearby_idx
-    assert abs(idx-nearby_idx) <=1
-    assert dataset.sequence_id_map[seq_id][dataset.get_frame_index(filename)]==filename
+    nearby_idx = dataset._get_nearby_frame_index(
+        "test/data/mjpeg/training/unlabelled/20210723_172608_031446.jpg", min_dist=1, max_dist=1
+    )
+    assert idx != nearby_idx
+    assert abs(idx - nearby_idx) <= 1
+    assert dataset.sequence_id_map[seq_id][dataset.get_frame_index(filename)] == filename
+
 
 def test_dataset_unlabelled_single_mode():
     dataset = MjpegDataset("test/data/mjpeg/training", single_image_mode=True, only_crops=False)
@@ -50,8 +61,8 @@ def test_dataset_unlabelled_single_mode():
     assert "image" in dataset[0]
     assert "sequence" in dataset[0]
     assert dataset[0]["sequence"] == "20210723_172608"
-    assert os.path.basename(dataset[0]["path"])!= dataset[0]["path"]
-    assert len(dataset.sequence_id_map)==4
+    assert os.path.basename(dataset[0]["path"]) != dataset[0]["path"]
+    assert len(dataset.sequence_id_map) == 4
     assert len(dataset.file_map) == len(dataset)
 
     for sample in dataset:
@@ -60,33 +71,99 @@ def test_dataset_unlabelled_single_mode():
         if INTERACTIVE:
             cv2.imshow("test", sample["image"])
             cv2.waitKey(1)
+
+
 import torchvision.transforms as transforms
 
-def test_dataset_unlabelled():
 
+def test_dataset_unlabelled():
     dataset = MjpegDataset("test/data/mjpeg/training", transform=None)
     assert len(dataset.unlabelled_files) > 0
     assert len(dataset) == 11
     sample = dataset[0]
     assert "sequence" in sample
     assert "crops" in sample
-    crop1, crop2 =  sample["crops"]
+    crop1, crop2 = sample["crops"]
     assert crop1.width != crop2.width
     assert isinstance(crop1, Image.Image)
-    transform = transforms.Compose([
-         transforms.ToTensor(),
-         transforms.Resize((224,224)),
-    ])
+    transform = transforms.Compose(
+        [
+            transforms.ToTensor(),
+            transforms.Resize((224, 224)),
+        ]
+    )
     dataset = MjpegDataset("test/data/mjpeg/training", transform=transform)
     assert isinstance(dataset.seq_subset, list)
     assert len(dataset.seq_subset) > 0
     assert isinstance(dataset.seq_subset[0], str)
     sample = dataset[0]
-    crop1, crop2 =  sample["crops"]
+    crop1, crop2 = sample["crops"]
+    assert sample["category"] == "unlabelled"
     assert isinstance(crop1, torch.Tensor)
-    assert crop1.shape==crop2.shape
-    assert crop1.shape==(3, 224,224)
+    assert crop1.shape == crop2.shape
+    assert crop1.shape == (3, 224, 224)
 
+
+def test_dataset_labelled():
+    dataset = MjpegDataset("test/data/mjpeg/training", transform=None, include_labelled=True, single_image_mode=True)
+    assert len(dataset.unlabelled_files) > 0
+    assert len(dataset) == 17
+    sample = dataset[0]
+    assert "sequence" in sample
+    assert "crops" not in sample
+    assert "image" in sample
+    image = sample["image"]
+    assert isinstance(image, Image.Image)
+    transform = transforms.Compose(
+        [
+            transforms.ToTensor(),
+            transforms.Resize((224, 224)),
+        ]
+    )
+    dataset = MjpegDataset("test/data/mjpeg/training", transform=transform, include_labelled=True, single_image_mode=True)
+    assert isinstance(dataset.seq_subset, list)
+    assert len(dataset.seq_subset) > 0
+    assert isinstance(dataset.seq_subset[0], str)
+    sample = dataset[-1]
+    image = sample["image"]
+    assert isinstance(image, torch.Tensor)
+    assert image.shape == (3, 224, 224)
+    assert sample["category"] == "speed_limit"
+
+
+def test_dataset_labelled_only():
+    dataset = MjpegDataset(
+        "test/data/mjpeg/training", transform=None, include_labelled=True, labelled_only=True, single_image_mode=True
+    )
+    assert len(dataset.unlabelled_files) > 0
+    assert len(dataset) == 6
+    sample = dataset[0]
+    assert "sequence" in sample
+    assert "crops" not in sample
+    assert "image" in sample
+    image = sample["image"]
+    assert isinstance(image, Image.Image)
+    for sample in dataset:
+        assert sample["category"] != "unlabelled"
+    transform = transforms.Compose(
+        [
+            transforms.ToTensor(),
+            transforms.Resize((224, 224)),
+        ]
+    )
+    dataset = MjpegDataset(
+        "test/data/mjpeg/training", transform=transform, include_labelled=True, labelled_only=True, single_image_mode=True
+    )
+    assert isinstance(dataset.seq_subset, list)
+    assert len(dataset.seq_subset) > 0
+    assert isinstance(dataset.seq_subset[0], str)
+    sample = dataset[-1]
+    image = sample["image"]
+    assert isinstance(image, torch.Tensor)
+    assert image.shape == (3, 224, 224)
+    assert sample["category"] == "speed_limit"
+    for sample in dataset:
+        assert sample["category"] != "unlabelled"
 
 
 def test_mjpeg_data_module():
@@ -101,9 +178,14 @@ def test_mjpeg_data_module():
     for sample in dataloader:
         assert sample["crops"] is not None
         crop1, crop2 = sample["crops"]
-        assert crop1.shape == (11, 3, 224,224)
+        assert crop1.shape == (11, 3, 224, 224)
         assert crop2.shape == (11, 3, 224, 224)
 
+
+import pytest
+
+
+@pytest.mark.skip(reason="Too long to test.")
 def test_mjpeg_data_module_full():
     dm = MjpegDataModule("/home/raphael/esmart/esmart-ai-datasets/data/esmart_mjpeg/")
     dm.setup()
@@ -111,12 +193,12 @@ def test_mjpeg_data_module_full():
     for sample in dm.train_dataset:
         assert sample["crops"] is not None
         crop1, crop2 = sample["crops"]
-        assert crop1.shape==crop2.shape
-        assert crop1.shape==(3,224,224)
+        assert crop1.shape == crop2.shape
+        assert crop1.shape == (3, 224, 224)
 
     dataloader = dm.train_dataloader()
     for sample in dataloader:
         assert sample["crops"] is not None
         crop1, crop2 = sample["crops"]
-        assert crop1.shape == (11, 3, 224,224)
+        assert crop1.shape == (11, 3, 224, 224)
         assert crop2.shape == (11, 3, 224, 224)

--- a/test/test_mjpeg_dataloader.py
+++ b/test/test_mjpeg_dataloader.py
@@ -29,8 +29,8 @@ def test_random_video_crop():
     else:
         crop_h, crop_w, _ = crop.shape
 
-    assert dataset.min_scale * crop_w < crop_w < dataset.max_scale * crop_w
-    assert dataset.min_scale * crop_h < crop_h < dataset.max_scale * crop_h
+    assert dataset.min_scale * crop_w <= crop_w <= dataset.max_scale * crop_w
+    assert dataset.min_scale * crop_h <= crop_h <= dataset.max_scale * crop_h
 
 
 def test_dataset_get_sequence_id_and_frame_number():
@@ -57,12 +57,12 @@ def test_get_nearby_frame_index():
 def test_dataset_unlabelled_single_mode():
     dataset = MjpegDataset("test/data/mjpeg/training", single_image_mode=True, only_crops=False)
     assert len(dataset.unlabelled_files) > 0
-    assert len(dataset) == 11
+    assert len(dataset) == 12
     assert "image" in dataset[0]
     assert "sequence" in dataset[0]
-    assert dataset[0]["sequence"] == "20210723_172608"
+    assert dataset[1]["sequence"] == "20210723_172608"
     assert os.path.basename(dataset[0]["path"]) != dataset[0]["path"]
-    assert len(dataset.sequence_id_map) == 4
+    assert len(dataset.sequence_id_map) == 5
     assert len(dataset.file_map) == len(dataset)
 
     for sample in dataset:
@@ -79,7 +79,7 @@ import torchvision.transforms as transforms
 def test_dataset_unlabelled():
     dataset = MjpegDataset("test/data/mjpeg/training", transform=None)
     assert len(dataset.unlabelled_files) > 0
-    assert len(dataset) == 11
+    assert len(dataset) == 12
     sample = dataset[0]
     assert "sequence" in sample
     assert "crops" in sample
@@ -107,7 +107,7 @@ def test_dataset_unlabelled():
 def test_dataset_labelled():
     dataset = MjpegDataset("test/data/mjpeg/training", transform=None, include_labelled=True, single_image_mode=True)
     assert len(dataset.unlabelled_files) > 0
-    assert len(dataset) == 17
+    assert len(dataset) == 18
     sample = dataset[0]
     assert "sequence" in sample
     assert "crops" not in sample
@@ -178,8 +178,8 @@ def test_mjpeg_data_module():
     for sample in dataloader:
         assert sample["crops"] is not None
         crop1, crop2 = sample["crops"]
-        assert crop1.shape == (11, 3, 224, 224)
-        assert crop2.shape == (11, 3, 224, 224)
+        assert crop1.shape == (12, 3, 224, 224)
+        assert crop2.shape == (12, 3, 224, 224)
 
 
 import pytest


### PR DESCRIPTION
Added support for MJPEG dataloader and training for self-supevised video experiment. The goal is to see if we can learn representations from raw videos, using either no annotations, or pseudo-annotations from an object detector. 

- Training with random crops from MJPEG
- Handles "pseudo-annotations" in "json" format, to take random crops around regions of interests
- Evaluation on "annotated" crops.
